### PR TITLE
Fix: Errors in cloud_run_job_module

### DIFF
--- a/modules/cloud_run_job/main.tf
+++ b/modules/cloud_run_job/main.tf
@@ -1,13 +1,21 @@
+# Enable the Secret Manager API
+resource "google_project_service" "secret_manager_api" {
+  service = "secretmanager.googleapis.com"
+  project = var.project
+  disable_on_destroy = false
+}
+
+# Create the required environment
 module "division_to_provider" {
   source = "../secret"
 
   project = var.project
   secret_id = "DIVISIONTOPROVIDER"
-  dragondrop_compute_service_account = var.dragondrop_compute_service_account
+  dragondrop_compute_service_account = var.dragondrop_compute_service_account_email
 }
 
 ## Defining the secrets needed for Environment variables of the Cloud Run Job
-resource "google_cloud_run_service_v2_job" "dragondrop-engine" {
+resource "google_cloud_run_v2_job" "dragondrop-engine" {
    name = var.cloud_run_job_name
    location = var.region
    project = var.project
@@ -22,7 +30,7 @@ resource "google_cloud_run_service_v2_job" "dragondrop-engine" {
 
           env {
             name = module.division_to_provider.secret_id
-            value_from {
+            value_source {
               secret_key_ref {
                 name = module.division_to_provider.secret_id
                 key  = "latest"

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -15,6 +15,6 @@ resource "google_secret_manager_secret_iam_member" "secret_access" {
   project = var.project
   secret_id = google_secret_manager_secret.secret.secret_id
   role = "roles/secretmanager.secretAccessor"
-  member = var.dragondrop_compute_service_account
+  member = "serviceAccount:${var.dragondrop_compute_service_account}"
   depends_on = [google_secret_manager_secret.secret]
 }


### PR DESCRIPTION
- Resource name `google_cloud_run_service_v2_job` --> `google_cloud_run_v2_job`
- Env secret `value_from` to `value_source`
- Add enablement of Secret Manager API for the project in question
- Service account member syntax bug